### PR TITLE
Improve timer readability with monospace font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 info.txt
+__pycache__/

--- a/main.py
+++ b/main.py
@@ -20,7 +20,8 @@ file_contents = [] #Contents of the file
 score, hscore = 0, 1 #Score and high score
 privileges_dict = {} #Creates a dictionary for optional privileges
 PrivilegesFlag = 0 #Flag to use privileges
-text_font = "Helvetica" #Font for text
+text_font = "Helvetica" #Font for general text
+mono_font = "Courier New" #Monospaced font for numbers
 
 #======Load File======
 try: #Tries to find and open file
@@ -177,27 +178,26 @@ def reset_time(): #Resets the time
 #======Top frame======
 TopFrame = tk.Frame(MainWindow, bg = bg_color)
 TopFrame.pack(fill = "both")
-{text_font}
-current_score = tk.Label(TopFrame, text = f"Score: {score}", fg = fg_color, bg = bg_color, font = ({text_font}, 22, "bold")) #Current Score Label
+current_score = tk.Label(TopFrame, text = f"Score: {score}", fg = fg_color, bg = bg_color, font = (mono_font, 22, "bold")) #Current Score Label
 current_score.pack(side = tk.LEFT)
 
-high_score = tk.Label(TopFrame, text = f"High Score: {score}", fg = fg_color, bg = bg_color, font = ({text_font}, 22, "bold")) #High Score Label
+high_score = tk.Label(TopFrame, text = f"High Score: {score}", fg = fg_color, bg = bg_color, font = (mono_font, 22, "bold")) #High Score Label
 high_score.pack(side = tk.RIGHT)
 
 #======Bottom frame======
 BottomFrame = tk.Frame(MainWindow, bg = bg_color)
 BottomFrame.pack(fill = "both")
 
-counter_before_label = tk.Label(BottomFrame, text = "It has been", fg = fg_color, bg = bg_color, font = ({text_font}, 24)) #Before Counter
+counter_before_label = tk.Label(BottomFrame, text = "It has been", fg = fg_color, bg = bg_color, font = (text_font, 24)) #Before Counter
 counter_before_label.pack()
 
-counter = tk.Label(BottomFrame, text = f"{d} Days, {h} Hours, {m} Minutes, and {s} Seconds", fg = fg_color, bg = bg_color, font = ({text_font}, 28)) #Counter
+counter = tk.Label(BottomFrame, text = f"{d} Days, {h} Hours, {m} Minutes, and {s} Seconds", fg = fg_color, bg = bg_color, font = (mono_font, 28)) #Counter
 counter.pack()
 
-counter_after_label = tk.Label(BottomFrame, text = "since you last logged.", fg = fg_color, bg = bg_color, font = ({text_font}, 22)) #After Counter
+counter_after_label = tk.Label(BottomFrame, text = "since you last logged.", fg = fg_color, bg = bg_color, font = (text_font, 22)) #After Counter
 counter_after_label.pack()
 
-counter_reset = tk.Button(BottomFrame, text = "Reset", activeforeground = fg_color, activebackground = bg_color, fg = fg_color, bg = bg_color, font = ({text_font}, 22), command = reset_time) #Reset Button
+counter_reset = tk.Button(BottomFrame, text = "Reset", activeforeground = fg_color, activebackground = bg_color, fg = fg_color, bg = bg_color, font = (text_font, 22), command = reset_time) #Reset Button
 counter_reset.pack()
 
 for line in range(7, len(file_contents)): #Goes through each line in file contents list from 7 to n to check for optional privileges
@@ -206,10 +206,10 @@ for line in range(7, len(file_contents)): #Goes through each line in file conten
     elif file_contents[line] == "\n": #Checks if line is whitespace
         continue #Ignores whitepsace
     else: #There are privileges to write
-        privileges_dict[f"privileges_label_{line - 6}"] = tk.Label(BottomFrame, text = file_contents[line].strip("\n"), fg = fg_color, bg = bg_color, font = ({text_font}, 16)) #Specific Privilege
+        privileges_dict[f"privileges_label_{line - 6}"] = tk.Label(BottomFrame, text = file_contents[line].strip("\n"), fg = fg_color, bg = bg_color, font = (text_font, 16)) #Specific Privilege
 if privileges_dict: #Checks if privileges label is necessary
     PrivilegesFlag = 1 #Sets flag
-    privileges_label = tk.Label(BottomFrame, text = "You are not allowed to:", fg = fg_color, bg = bg_color, font = ({text_font}, 20)) #Privileges
+    privileges_label = tk.Label(BottomFrame, text = "You are not allowed to:", fg = fg_color, bg = bg_color, font = (text_font, 20)) #Privileges
     privileges_label.pack() #Packs privileges label
     for privilege in privileges_dict: #Goes through specific privileges
         privileges_dict[privilege].pack() #Packs specific privileges

--- a/test_gui.py
+++ b/test_gui.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+class TestMonoFont(unittest.TestCase):
+    def setUp(self):
+        self.patcher_tk = patch('tkinter.Tk', return_value=MagicMock(after=lambda *a, **k: None, mainloop=lambda: None))
+        self.patcher_frame = patch('tkinter.Frame', return_value=MagicMock())
+        self.patcher_label = patch('tkinter.Label', return_value=MagicMock())
+        self.patcher_button = patch('tkinter.Button', return_value=MagicMock())
+        self.mock_tk = self.patcher_tk.start()
+        self.mock_frame = self.patcher_frame.start()
+        self.mock_label = self.patcher_label.start()
+        self.mock_button = self.patcher_button.start()
+
+    def tearDown(self):
+        self.patcher_tk.stop()
+        self.patcher_frame.stop()
+        self.patcher_label.stop()
+        self.patcher_button.stop()
+        if 'main' in sys.modules:
+            del sys.modules['main']
+
+    def test_mono_font_used_in_numeric_labels(self):
+        import main
+        fonts = []
+        for call in self.mock_label.call_args_list:
+            kwargs = call.kwargs
+            text = kwargs.get('text', '')
+            if 'Score:' in text or 'High Score' in text or 'Days' in text:
+                fonts.append(kwargs.get('font'))
+        self.assertTrue(fonts)
+        for font in fonts:
+            self.assertEqual(font[0], main.mono_font)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `mono_font` variable
- use the monospaced font in the score and timer labels
- clean up leftover placeholder text

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686fbaa10c50832daf5076453cf1ce90